### PR TITLE
Fix ParseCommaExpression

### DIFF
--- a/src/jast/parser.cc
+++ b/src/jast/parser.cc
@@ -526,17 +526,17 @@ Expression* Parser::ParseCommaExpression()
         return one;
 
     ExpressionList *exprs = builder()->NewExpressionList();
+    exprs->Insert(one);
 
     // loop until we don't find a ','
     while (true) {
-        exprs->Insert(one);
-
         advance();
         one = ParseAssignExpression();
+        exprs->Insert(one);
 
         tok = peek();
         if (tok != COMMA)
-            break;   
+            break;
     }
 
     return builder()->NewCommaExpression(exprs);


### PR DESCRIPTION
For example, parsing "a = 1+2, b = 3;" or "if (false, true)" would return CommaExpression with only one child because parser ignores last expression (parses it but doesn't push it to the expression list). This small pull request fixes that.